### PR TITLE
Remove var_dump() in FileLoaderTest

### DIFF
--- a/tests/FileLoaderTest.php
+++ b/tests/FileLoaderTest.php
@@ -71,7 +71,6 @@ class FileLoaderTest extends PHPUnit_Framework_TestCase {
 		$loader = $this->getLoader();
 		$loader->addNamespace('namespace', __DIR__.'/namespace');
 		$loader->getFilesystem()->shouldReceive('exists')->with(__DIR__.'/namespace/app.php')->andReturn(false);
-		var_dump('here');
 		$this->assertFalse($loader->exists('app', 'namespace'));
 	}
 


### PR DESCRIPTION
Removing a left over var_dump('here') in a test.
